### PR TITLE
Fix for K20x startup

### DIFF
--- a/os/hal/ports/KINETIS/K20x/hal_lld.c
+++ b/os/hal/ports/KINETIS/K20x/hal_lld.c
@@ -148,11 +148,10 @@ void k20x_clock_init(void) {
    *       frequency, which would required other registers to be modified.
    */
   /* Enable OSC, low power mode */
-  MCG->C2 = MCG_C2_LOCRE0 | MCG_C2_EREFS0;
   if (KINETIS_XTAL_FREQUENCY > 8000000UL)
-    MCG->C2 |= MCG_C2_RANGE0(2);
+    MCG->C2 = MCG_C2_LOCRE0 | MCG_C2_EREFS0 | MCG_C2_RANGE0(2);
   else
-    MCG->C2 |= MCG_C2_RANGE0(1);
+    MCG->C2 = MCG_C2_LOCRE0 | MCG_C2_EREFS0 | MCG_C2_RANGE0(1);
 
   frdiv = 7;
   ratio = KINETIS_XTAL_FREQUENCY / 31250UL;


### PR DESCRIPTION
While working on QMK support for the K-Type keyboard (which uses this code) I ran into an issue where it would only start up about a third of the time. It was hanging on this:

```
   /* Wait for the MCGOUTCLK to use the oscillator */¬
   while ((MCG->S & MCG_S_CLKST_MASK) != MCG_S_CLKST(2));¬
```

I stumbled on this solution by accident but it seems to fix the issue. I assume setting this value using multiple operations puts it into a weird state.

https://github.com/qmk/qmk_firmware/pull/1963